### PR TITLE
Support passing kwargs to `requests.request` in `apexecute`

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -332,8 +332,18 @@ class Salesforce(object):
         # so check whether there are more results and retrieve them if so.
         return get_all_results(result, **kwargs)
 
-    def apexecute(self, action, method='GET', data=None):
-        result = self._call_salesforce(method, self.apex_url + action, data=json.dumps(data))
+    def apexecute(self, action, method='GET', data=None, **kwargs):
+        """Makes an HTTP request to an APEX REST endpoint
+
+        Arguments:
+
+        * action -- The REST endpoint for the request.
+        * method -- HTTP method for the request (default GET)
+        * data -- A dict of parameters to send in a POST / PUT request
+        * kwargs -- Additional kwargs to pass to `requests.request`
+        """
+        result = self._call_salesforce(method, self.apex_url + action,
+                                       data=json.dumps(data), **kwargs)
 
         if result.status_code == 200:
             try:


### PR DESCRIPTION
This allows you to pass other keyword args into `apexecute` for timeouts, etc