### PR TITLE
Fix upsert/update/delete to optionally return response body

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -454,11 +454,7 @@ class SFType(object):
         """
         result = self._call_salesforce('PATCH', self.base_url + record_id,
                                        data=json.dumps(data))
-        if response_body:
-            return result.status_code
-        else:
-            return (result.status_code,
-                    result.json(object_pairs_hook=OrderedDict))
+        return self._response_body(result, response_body)
 
     def update(self, record_id, data, response_body=False):
         """Updates an SObject using a PATCH to
@@ -476,11 +472,7 @@ class SFType(object):
         """
         result = self._call_salesforce('PATCH', self.base_url + record_id,
                                        data=json.dumps(data))
-        if response_body:
-            return result.status_code
-        else:
-            return (result.status_code,
-                    result.json(object_pairs_hook=OrderedDict))
+        return self._response_body(result, response_body)
 
     def delete(self, record_id, response_body=False):
         """Deletes an SObject using a DELETE to
@@ -495,11 +487,7 @@ class SFType(object):
         * record_id -- the Id of the SObject to delete
         """
         result = self._call_salesforce('DELETE', self.base_url + record_id)
-        if response_body:
-            return result.status_code
-        else:
-            return (result.status_code,
-                    result.json(object_pairs_hook=OrderedDict))
+        return self._response_body(result, response_body)
 
     def deleted(self, start, end):
         """Use the SObject Get Deleted resource to get a list of deleted records for the specified object.
@@ -544,6 +532,17 @@ class SFType(object):
 
         return result
 
+    def _response_body(self, response, body_flag):
+        """Utility method for processing the response and returning either the
+        status code or a tuple of (status_code, response_dict)"""
+        if not body_flag:
+            return response.status_code
+
+        if response.headers['Content-Length'] == 0:
+            return (response.status_code, {})
+        else:
+            return (response.status_code,
+                    response.json(object_pairs_hook=OrderedDict)
 
 class SalesforceAPI(Salesforce):
     """Depreciated SalesforceAPI Instance

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -436,11 +436,14 @@ class SFType(object):
                                        data=json.dumps(data))
         return result.json(object_pairs_hook=OrderedDict)
 
-    def upsert(self, record_id, data):
+    def upsert(self, record_id, data, response_body=False):
         """Creates or updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
 
-        Returns a dict decoded from the JSON payload returned by Salesforce.
+        If `response_body` is false (the default), returns the status code
+        returned by Salesforce. Otherwise, returns a tuple of the status code
+        and the dict decoded from the JSON payload returned by Salesforce.
+
 
         Arguments:
 
@@ -451,13 +454,19 @@ class SFType(object):
         """
         result = self._call_salesforce('PATCH', self.base_url + record_id,
                                        data=json.dumps(data))
-        return result.status_code
+        if response_body:
+            return result.status_code
+        else:
+            return (result.status_code,
+                    result.json(object_pairs_hook=OrderedDict))
 
-    def update(self, record_id, data):
+    def update(self, record_id, data, response_body=False):
         """Updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
 
-        Returns a dict decoded from the JSON payload returned by Salesforce.
+        If `response_body` is false (the default), returns the status code
+        returned by Salesforce. Otherwise, returns a tuple of the status code
+        and the dict decoded from the JSON payload returned by Salesforce.
 
         Arguments:
 
@@ -467,20 +476,30 @@ class SFType(object):
         """
         result = self._call_salesforce('PATCH', self.base_url + record_id,
                                        data=json.dumps(data))
-        return result.status_code
+        if response_body:
+            return result.status_code
+        else:
+            return (result.status_code,
+                    result.json(object_pairs_hook=OrderedDict))
 
-    def delete(self, record_id):
+    def delete(self, record_id, response_body=False):
         """Deletes an SObject using a DELETE to
         `.../{object_name}/{record_id}`.
 
-        Returns a dict decoded from the JSON payload returned by Salesforce.
+        If `response_body` is false (the default), returns the status code
+        returned by Salesforce. Otherwise, returns a tuple of the status code
+        and the dict decoded from the JSON payload returned by Salesforce.
 
         Arguments:
 
         * record_id -- the Id of the SObject to delete
         """
         result = self._call_salesforce('DELETE', self.base_url + record_id)
-        return result.status_code
+        if response_body:
+            return result.status_code
+        else:
+            return (result.status_code,
+                    result.json(object_pairs_hook=OrderedDict))
 
     def deleted(self, start, end):
         """Use the SObject Get Deleted resource to get a list of deleted records for the specified object.

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -436,14 +436,13 @@ class SFType(object):
                                        data=json.dumps(data))
         return result.json(object_pairs_hook=OrderedDict)
 
-    def upsert(self, record_id, data, response_body=False):
+    def upsert(self, record_id, data, raw_response=False):
         """Creates or updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
 
-        If `response_body` is false (the default), returns the status code
-        returned by Salesforce. Otherwise, returns a tuple of the status code
-        and the dict decoded from the JSON payload returned by Salesforce.
-
+        If `raw_response` is false (the default), returns the status code
+        returned by Salesforce. Otherwise, return the `requests.Response`
+        object.
 
         Arguments:
 
@@ -451,43 +450,49 @@ class SFType(object):
                        Salesforce documentation
         * data -- a dict of the data to create or update the SObject from. It
                   will be JSON-encoded before being transmitted.
+        * raw_response -- a boolean indicating whether to return the response
+                          directly, instead of the status code.
         """
         result = self._call_salesforce('PATCH', self.base_url + record_id,
                                        data=json.dumps(data))
-        return self._response_body(result, response_body)
+        return self._raw_response(result, raw_response)
 
-    def update(self, record_id, data, response_body=False):
+    def update(self, record_id, data, raw_response=False):
         """Updates an SObject using a PATCH to
         `.../{object_name}/{record_id}`.
 
-        If `response_body` is false (the default), returns the status code
-        returned by Salesforce. Otherwise, returns a tuple of the status code
-        and the dict decoded from the JSON payload returned by Salesforce.
+        If `raw_response` is false (the default), returns the status code
+        returned by Salesforce. Otherwise, return the `requests.Response`
+        object.
 
         Arguments:
 
         * record_id -- the Id of the SObject to update
         * data -- a dict of the data to update the SObject from. It will be
                   JSON-encoded before being transmitted.
+        * raw_response -- a boolean indicating whether to return the response
+                          directly, instead of the status code.
         """
         result = self._call_salesforce('PATCH', self.base_url + record_id,
                                        data=json.dumps(data))
-        return self._response_body(result, response_body)
+        return self._raw_response(result, raw_response)
 
-    def delete(self, record_id, response_body=False):
+    def delete(self, record_id, raw_response=False):
         """Deletes an SObject using a DELETE to
         `.../{object_name}/{record_id}`.
 
-        If `response_body` is false (the default), returns the status code
-        returned by Salesforce. Otherwise, returns a tuple of the status code
-        and the dict decoded from the JSON payload returned by Salesforce.
+        If `raw_response` is false (the default), returns the status code
+        returned by Salesforce. Otherwise, return the `requests.Response`
+        object.
 
         Arguments:
 
         * record_id -- the Id of the SObject to delete
+        * raw_response -- a boolean indicating whether to return the response
+                          directly, instead of the status code.
         """
         result = self._call_salesforce('DELETE', self.base_url + record_id)
-        return self._response_body(result, response_body)
+        return self._raw_response(result, raw_response)
 
     def deleted(self, start, end):
         """Use the SObject Get Deleted resource to get a list of deleted records for the specified object.
@@ -532,18 +537,16 @@ class SFType(object):
 
         return result
 
-    def _response_body(self, response, body_flag):
+    def _raw_response(self, response, body_flag):
         """Utility method for processing the response and returning either the
-        status code or a tuple of (status_code, response_dict)"""
+        status code or the response object.
+
+        Returns either an `int` or a `requests.Response` object.
+        """
         if not body_flag:
             return response.status_code
-
-        if response.headers['Content-Length'] == 0:
-            return (response.status_code, {})
         else:
-            return (response.status_code,
-                    response.json(object_pairs_hook=OrderedDict))
-
+            return response
 
 class SalesforceAPI(Salesforce):
     """Depreciated SalesforceAPI Instance

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -542,7 +542,8 @@ class SFType(object):
             return (response.status_code, {})
         else:
             return (response.status_code,
-                    response.json(object_pairs_hook=OrderedDict)
+                    response.json(object_pairs_hook=OrderedDict))
+
 
 class SalesforceAPI(Salesforce):
     """Depreciated SalesforceAPI Instance


### PR DESCRIPTION
When using `upsert` to create a record, it's convenient to be able to inspect the response. Added similar code to update and delete for symmetry.