### PR TITLE
simple wrapper for tooling api requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,9 @@ You can access the Metadata Tooling API using this library::
 
 This would call the endpoint ``https://<instance>.salesforce.com/services/data/<version>/tooling/`` with a query against the TraceFlag Tooling API object
 
+You can read more about the Tooling API on the `Using Tooling REST API`_
+
+.. _Using Tooling REST API: http://www.salesforce.com/us/developer/docs/api_tooling/Content/intro_rest_overview.htm
 
 Additional Features
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,17 @@ You can read more about Apex on the `Force.com Apex Code Developer's Guide`_
 
 .. _Force.com Apex Code Developer's Guide: http://www.salesforce.com/us/developer/docs/apexcode
 
+
+Using Tooling API
+-----------------
+
+You can access the Metadata Tooling API using this library::
+
+    result = sf.tooling( 'query/?q=Select+id,ApexProfiling+from+TraceFlag' , {}))
+
+This would call the endpoint ``https://<instance>.salesforce.com/services/data/<version>/tooling/`` with a query against the TraceFlag Tooling API object
+
+
 Additional Features
 -------------------
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -121,6 +121,9 @@ class Salesforce(object):
                                  version=self.sf_version))
         self.apex_url = ('https://{instance}/services/apexrest/'
                          .format(instance=self.sf_instance))
+        self.tool_url = ('https://{instance}/services/data/v{version}/tooling/'
+                            .format(instance=self.sf_instance,
+                                 version=self.sf_version))
 
     def describe(self):
         url = self.base_url + "sobjects"
@@ -194,6 +197,27 @@ class Salesforce(object):
         """
 
         url = self.base_url + path
+        result = self.request.get(url, headers=self.headers, params=params)
+        if result.status_code != 200:
+            raise SalesforceGeneralError(result.content)
+        json_result = result.json(object_pairs_hook=OrderedDict)
+        if len(json_result) == 0:
+            return None
+        else:
+            return json_result
+    
+    # Generic Tooling API Function
+    def tooling(self,path,params):
+        """Allows you to make a direct Tooling REST call if you know the path
+
+        Arguments:
+
+        * path: The path of the request
+            Example: sobjects/User'
+        * params: dict of parameters to pass to the path
+        """
+
+        url = self.tool_url + path
         result = self.request.get(url, headers=self.headers, params=params)
         if result.status_code != 200:
             raise SalesforceGeneralError(result.content)


### PR DESCRIPTION
simple copy of the restful() method with the tooling API path added for connivence.